### PR TITLE
Add app_name to url module

### DIFF
--- a/django_app_lti/urls.py
+++ b/django_app_lti/urls.py
@@ -1,6 +1,7 @@
 from django.urls import path
 from .views import LTILaunchView, LTIToolConfigView, logout_view, logged_out_view
 
+app_name = 'lti'
 urlpatterns = [
     path('', LTILaunchView.as_view(), name='index'),
     path('launch', LTILaunchView.as_view(), name='launch'),


### PR DESCRIPTION
`app_name` was removed from `include()`, but you can add it to your url module. See https://code.djangoproject.com/ticket/28691.

As such, this PR adds `app_name` to the url module. This is so as to get around the associated error when using this django-app-lti package.